### PR TITLE
Provide a limited form of static asset support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,34 @@ $ node index.js --help
 Usage: index.js [options] -t <template> -c <config>
 
 Options:
-  --template, -t  path to page template                               [required]
-  --config, -c    path to page config JSON                            [required]
+  --template, -t  path to page template                                [required]
+  --config, -c    path to page config JSON                             [required]
   --cert          use specified client certificate for TLS
   --cacert        use specified CA certificate for TLS
-  --labels        show component labels to help with debugging  [default: false]
-  --noerrors      do not display request errors in markup       [default: false]
+  --labels        show component labels to help with debugging         [default: false]
+  --noerrors      do not display request errors in markup              [default: false]
+  --staticprefix  prefix which identifies a request for a static asset [default: /img]
+  --statichost    where to send requests for static assets             [default: localhost]
+  --staticpath    path on the statichost where the static assets are   [default: /img]
   --help          Show help                                            [boolean]
 ```
 
 Once the server is running, point your browser at http://localhost:3000/
+
+The `staticprefix`, `statichost` and `staticpath` are used to provide access to static assets.
+For example, if your CSS has an image sprite addressed as `url(img/news--icons-sprite.png)`, by running
+a local webserver on port 80 in the same directory as the `img` directory, and using the default values,
+requests to `localhost:3000/img/news--icons-sprite.png` will be proxied to `localhost:/img/news--icons-sprite.png`
+
+Another example is using the build-in web server on the Mac and creating a symlink to your Morph module:
+
+```
+cd /Library/WebServer/Documents
+ln -s /Users/myusername/morph-modules/my-morph-module my-morph-module
+```
+
+The Salieri parameters would be `--staticprefix /img --statichost localhost --staticpath my-morph-module/public/img`.
+
 
 ## Parameters
 

--- a/index.js
+++ b/index.js
@@ -31,10 +31,22 @@ const argv = require('yargs')
         describe: 'do not display request errors in markup',
         default: false
     })
+    .option('staticprefix', {
+        describe: 'prefix which identifies a request for a static asset',
+        default: '/img'
+    })
+    .option('statichost', {
+        describe: 'where to send requests for static assets',
+        default: 'localhost'
+    })
+    .option('staticpath', {
+        describe: 'path on the statichost where the static assets are',
+        default: '/img'
+    })
     .help('help')
     .argv;
 
-const readFile = (filename) => fs.readFileSync(filename, 'utf-8');
+const readFile = filename => fs.readFileSync(filename, 'utf-8');
 
 const template = readFile(argv.template);
 const config = readFile(argv.config);
@@ -58,5 +70,5 @@ const buildPage = createBuilder(template, config, rp, Envelope);
 
 const server = require('./lib/server');
 
-server.createServer(buildPage)
-    .listen(SERVER_PORT, () => console.log('Listening on port %d', SERVER_PORT));
+server.createServer(buildPage, argv.staticprefix, argv.statichost, argv.staticpath)
+    .listen(SERVER_PORT, () => console.log('Listening on port %d', SERVER_PORT, ', images served from', argv.statichost));

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,14 +1,25 @@
 'use strict';
 
 const express = require('express');
+const proxy = require('express-http-proxy');
 
-function createServer(buildPage) {
-    return express()
-        .get('/', (req, res, next) =>
-            buildPage(req.query)
-                .then((page) => res.send(page))
-                .catch(next)
-        );
+function createServer(buildPage, staticPrefix, staticHost, staticPath) {
+    const app = express();
+
+    app.use(staticPrefix, proxy(staticHost, {
+        preserveHostHdr: true,
+        forwardPath: function(req, res) {
+          console.log("static asset request: ", staticPath + req.url);
+          return staticPath + req.url;
+        }
+    }));
+
+    app.get('/', (req, res, next) =>
+        buildPage(req.query)
+            .then((page) => res.send(page))
+            .catch(next)
+    );
+    return app;
 }
 
 exports.createServer = createServer;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.13.4",
+    "express-http-proxy": "^0.9.1",
     "lodash": "^4.11.2",
     "mustache": "^2.2.1",
     "request-promise": "^3.0.0",


### PR DESCRIPTION
Proxies requests to Salieri that start with a specific path (e.g. `/img`) to another web server so that static assets can be served.
